### PR TITLE
Updated lscachebase.php

### DIFF
--- a/3.0/upload/system/library/lscache/lscachebase.php
+++ b/3.0/upload/system/library/lscache/lscachebase.php
@@ -46,7 +46,7 @@ class LiteSpeedCacheBase
         }
         
         foreach ($tags as $tag) {
-            if(empty(trim($tag))){
+            if(strlen(trim($tag)) === 0){
                 continue;
             }
             


### PR DESCRIPTION
#236526 - Needs to not rely on native construct `empty()` as it only accept non-variables after PHP 5.5.x.  The purpose of line 49 was to check if the tag given was empty, so `strlen() === 0` should do the same and is version agnostic.